### PR TITLE
Use polygon instead of line for arrow in restore-trash

### DIFF
--- a/src/icons.svg
+++ b/src/icons.svg
@@ -488,19 +488,8 @@
 
 
 <symbol id="restore-trash">
-    <defs>
-      <style>
-        .a {
-        fill: none;
-        stroke: #000;
-        stroke-miterlimit: 10;
-        stroke-width: 2px;
-        }
-      </style>
-    </defs>
-    <polygon points="9 12 12 9 15 12 9 12"/>
-    <path d="M19,6H15V3H9V6H5V8H6V21H18V8h1V6ZM11,5h2V6H11V5Zm5,14H8V8h8V19Z"/>
-    <line class="a" x1="12" y1="10" x2="12" y2="17"/>
+  <polygon points="9,12 12,9 15,12 13,12 13,17 11,17 11,12 9,12"/>
+  <path d="M19,6H15V3H9V6H5V8H6V21H18V8h1V6ZM11,5h2V6H11V5Zm5,14H8V8h8V19Z"/>
 </symbol>
 
 <symbol id="rotate-ccw">


### PR DESCRIPTION
Related to: gyselroth/balloon-client-web/issues/166

Also removes hardcoded color.